### PR TITLE
Add Sophisticated experience to the default value of accepted fluids

### DIFF
--- a/src/main/java/com/cyanogen/experienceobelisk/config/Config.java
+++ b/src/main/java/com/cyanogen/experienceobelisk/config/Config.java
@@ -21,6 +21,7 @@ public class Config {
             defaultValues.add("mob_grinding_utils:fluid_xp");
             defaultValues.add("cofh_core:experience");
             defaultValues.add("industrialforegoing:essence");
+            defaultValues.add("sophisticatedcore:xp_still");
 
             builder.push("Allowed Experience Fluids");
             this.allowedFluids = builder.comment("Add IDs of fluids you want the obelisk to support here in the form mod_id:fluid_name")


### PR DESCRIPTION
Sophisticated Backpacks and Sophisticated Storage has it's own experience fluid, and I like to see support for it by default from Experience Obelisk.

Originated by FTBTeam/FTB-Modpack-Issues#4058 issue report