### PR TITLE
Feature: Add new EnderIO xp to defaults

### DIFF
--- a/src/main/java/com/cyanogen/experienceobelisk/config/Config.java
+++ b/src/main/java/com/cyanogen/experienceobelisk/config/Config.java
@@ -22,6 +22,7 @@ public class Config {
             defaultValues.add("cofh_core:experience");
             defaultValues.add("industrialforegoing:essence");
             defaultValues.add("sophisticatedcore:xp_still");
+            defaultValues.add("enderio:xp_juice");
 
             builder.push("Allowed Experience Fluids");
             this.allowedFluids = builder.comment("Add IDs of fluids you want the obelisk to support here in the form mod_id:fluid_name")


### PR DESCRIPTION
Hey there! I didn't see a CONTRIBUTING.md so I figured this might be something that I can just open. I've tested it in my own instance and have confirmed that the FluidTank from EnderIO is able to extract directly to the obelisk. The two attached screenshots (as I didn't have a chance to record video but I can try to get it if needed) show the decrease from the fluid tank with a push into the obelisk.
![2023-10-22_12 45 45](https://github.com/terrarium-earth/Experience-Obelisk/assets/6376099/4188a98b-40d1-4376-b3cf-4350d686753e)
![2023-10-22_12 45 48](https://github.com/terrarium-earth/Experience-Obelisk/assets/6376099/414d247a-2f2e-4ab6-99fc-6debcdfc839f)
