### PR TITLE
Remove System.out NBT dump in ProtectionSalveItem

### DIFF
--- a/src/main/java/com/cyanogen/cognition/item/ProtectionSalveItem.java
+++ b/src/main/java/com/cyanogen/cognition/item/ProtectionSalveItem.java
@@ -21,7 +21,6 @@ public class ProtectionSalveItem extends Item {
 
         CompoundTag tag = new CompoundTag();
         entity.save(tag);
-        System.out.println(tag);
 
     }
 }


### PR DESCRIPTION
in bigger modpacks like FTB Evolution this could cause massive amounts of logging

e.g.:
[filtered.log](https://github.com/user-attachments/files/28480561/filtered.log)
